### PR TITLE
fix: address deprecation warnings

### DIFF
--- a/tests/test_vxi11.py
+++ b/tests/test_vxi11.py
@@ -1,48 +1,46 @@
 #!/usr/bin/env python
 
-import nose
-from nose.tools import eq_
 from vxi11.vxi11 import parse_visa_resource_string
+
 
 def test_parse_visa_resource_string():
     f = parse_visa_resource_string
 
     res = f('TCPIP::10.0.0.1::INSTR')
-    eq_(res['type'], 'TCPIP')
-    eq_(res['prefix'], 'TCPIP')
-    eq_(res['arg1'], '10.0.0.1')
-    eq_(res['suffix'], 'INSTR')
+    assert res['type'] == 'TCPIP'
+    assert res['prefix'] == 'TCPIP'
+    assert res['arg1'] == '10.0.0.1'
+    assert res['suffix'] == 'INSTR'
 
     res = f('TCPIP0::10.0.0.1::INSTR')
-    eq_(res['type'], 'TCPIP')
-    eq_(res['prefix'], 'TCPIP0')
-    eq_(res['arg1'], '10.0.0.1')
-    eq_(res['suffix'], 'INSTR')
+    assert res['type'] == 'TCPIP'
+    assert res['prefix'] == 'TCPIP0'
+    assert res['arg1'] == '10.0.0.1'
+    assert res['suffix'] == 'INSTR'
 
     res = f('TCPIP::10.0.0.1::gpib,5::INSTR')
-    eq_(res['type'], 'TCPIP')
-    eq_(res['prefix'], 'TCPIP')
-    eq_(res['arg1'], '10.0.0.1')
-    eq_(res['suffix'], 'INSTR')
+    assert res['type'] == 'TCPIP'
+    assert res['prefix'] == 'TCPIP'
+    assert res['arg1'] == '10.0.0.1'
+    assert res['suffix'] == 'INSTR'
 
     res = f('TCPIP0::10.0.0.1::gpib,5::INSTR')
-    eq_(res['type'], 'TCPIP')
-    eq_(res['prefix'], 'TCPIP0')
-    eq_(res['arg1'], '10.0.0.1')
-    eq_(res['arg2'], 'gpib,5')
-    eq_(res['suffix'], 'INSTR')
+    assert res['type'] == 'TCPIP'
+    assert res['prefix'] == 'TCPIP0'
+    assert res['arg1'] == '10.0.0.1'
+    assert res['arg2'] == 'gpib,5'
+    assert res['suffix'] == 'INSTR'
 
     res = f('TCPIP0::10.0.0.1::usb0::INSTR')
-    eq_(res['type'], 'TCPIP')
-    eq_(res['prefix'], 'TCPIP0')
-    eq_(res['arg1'], '10.0.0.1')
-    eq_(res['arg2'], 'usb0')
-    eq_(res['suffix'], 'INSTR')
+    assert res['type'] == 'TCPIP'
+    assert res['prefix'] == 'TCPIP0'
+    assert res['arg1'] == '10.0.0.1'
+    assert res['arg2'] == 'usb0'
+    assert res['suffix'] == 'INSTR'
 
     res = f('TCPIP0::10.0.0.1::usb0[1234::5678::MYSERIAL::0]::INSTR')
-    eq_(res['type'], 'TCPIP')
-    eq_(res['prefix'], 'TCPIP0')
-    eq_(res['arg1'], '10.0.0.1')
-    eq_(res['arg2'], 'usb0[1234::5678::MYSERIAL::0]')
-    eq_(res['suffix'], 'INSTR')
-
+    assert res['type'] == 'TCPIP'
+    assert res['prefix'] == 'TCPIP0'
+    assert res['arg1'] == '10.0.0.1'
+    assert res['arg2'] == 'usb0[1234::5678::MYSERIAL::0]'
+    assert res['suffix'] == 'INSTR'

--- a/vxi11/vxi11.py
+++ b/vxi11/vxi11.py
@@ -131,8 +131,8 @@ def parse_visa_resource_string(resource_string):
     # TCPIP0::10.0.0.1::gpib,5::INSTR
     # TCPIP0::10.0.0.1::usb0::INSTR
     # TCPIP0::10.0.0.1::usb0[1234::5678::MYSERIAL::0]::INSTR
-    m = re.match('^(?P<prefix>(?P<type>TCPIP)\d*)(::(?P<arg1>[^\s:]+))'
-            '(::(?P<arg2>[^\s:]+(\[.+\])?))?(::(?P<suffix>INSTR))$',
+    m = re.match(r'^(?P<prefix>(?P<type>TCPIP)\d*)(::(?P<arg1>[^\s:]+))'
+            r'(::(?P<arg2>[^\s:]+(\[.+\])?))?(::(?P<suffix>INSTR))$',
             resource_string, re.I)
 
     if m is not None:


### PR DESCRIPTION
The following warnings were output when running the tests:

```
venv/lib/python3.8/site-packages/nose/importer.py:12
  /home/matt.hanley/github/loft-orbital/python-vxi11/venv/lib/python3.8/site-packages/nose/importer.py:12: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    from imp import find_module, load_module, acquire_lock, release_lock

vxi11/vxi11.py:134
  /home/matt.hanley/github/loft-orbital/python-vxi11/vxi11/vxi11.py:134: DeprecationWarning: invalid escape sequence \d
    m = re.match('^(?P<prefix>(?P<type>TCPIP)\d*)(::(?P<arg1>[^\s:]+))'

vxi11/vxi11.py:135
  /home/matt.hanley/github/loft-orbital/python-vxi11/vxi11/vxi11.py:135: DeprecationWarning: invalid escape sequence \s
    '(::(?P<arg2>[^\s:]+(\[.+\])?))?(::(?P<suffix>INSTR))$',

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

This fixes them by updating the regex string and removing the dependency on `nose` in favor of simply `assert`